### PR TITLE
add filter for user_ID in badgeos_bp_trigger_event

### DIFF
--- a/includes/rules-engine.php
+++ b/includes/rules-engine.php
@@ -46,6 +46,8 @@ function badgeos_bp_trigger_event( $args = '' ) {
 		$user_ID = absint( $args[1] );
 	}
 
+	$user_ID = apply_filters('badgeos_bp_trigger_user_id', $user_ID, current_filter(), $args);
+
 	$user_data = get_user_by( 'id', $user_ID );
 
 	// Sanity check, if we don't have a user object, bail here


### PR DESCRIPTION
I need this to implement the extension talked about in #57 . Besides, I think this is a good approach to make ```badgeos_bp_trigger_event``` more generic. Also lines https://github.com/opencredit/BadgeOS-Community-Add-on/blob/master/includes/rules-engine.php#L41:L47 could be rewritten using this filter.