### PR TITLE
Fixed: PHP 7.1.8 Fatal Error: Uncaught Error: [] operator not support…

### DIFF
--- a/includes/bp-members.php
+++ b/includes/bp-members.php
@@ -143,7 +143,7 @@ class BadgeOS_Community_Members extends BP_Component {
 	}
 
 	// Member Profile Menu
-	public function setup_nav( $main_nav = '', $sub_nav = '' ) {
+	public function setup_nav( $main_nav = array(), $sub_nav = array() ) {
 
 		if ( ! is_user_logged_in() && ! bp_displayed_user_id() )
 			return;


### PR DESCRIPTION
…ed for strings

Resolves this issue posted on wp support forum
https://wordpress.org/support/topic/php-7-1-8-fatal-error-uncaught-error-operator-not-supported-for-strings/